### PR TITLE
Add interactive globe page with Warsaw popup

### DIFF
--- a/app/globe/page.module.css
+++ b/app/globe/page.module.css
@@ -1,0 +1,31 @@
+.globePage {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+}
+
+.globeCanvas {
+  width: 100%;
+  height: 100%;
+}
+
+.popupOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.popupContent {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  max-width: 300px;
+  text-align: center;
+}

--- a/app/globe/page.tsx
+++ b/app/globe/page.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useState, MouseEvent } from 'react'
+import dynamic from 'next/dynamic'
+import styles from './page.module.css'
+
+const Globe = dynamic(() => import('react-globe.gl'), { ssr: false }) as any
+
+export default function GlobePage() {
+  const [showPopup, setShowPopup] = useState(false)
+
+  const points = [{ lat: 52.2297, lng: 21.0122, size: 0.5 }]
+
+  const handlePointClick = () => setShowPopup(true)
+  const hidePopup = () => setShowPopup(false)
+  const stopPropagation = (e: MouseEvent) => e.stopPropagation()
+
+  return (
+    <div className={styles.globePage}>
+      <div className={styles.globeCanvas}>
+        <Globe
+          globeImageUrl="//unpkg.com/three-globe/example/img/earth-day.jpg"
+          pointsData={points}
+          pointAltitude={0.1}
+          pointColor={() => '#ff5722'}
+          onPointClick={handlePointClick}
+        />
+      </div>
+      {showPopup && (
+        <div className={styles.popupOverlay} onClick={hidePopup}>
+          <div className={styles.popupContent} onClick={stopPropagation}>
+            <h2>Warsaw</h2>
+            <p>Mockup information about Warsaw.</p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "14.0.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-globe.gl": "^2.24.13"
   },
   "devDependencies": {
     "@types/node": "20.19.10",

--- a/react-globe.gl.d.ts
+++ b/react-globe.gl.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-globe.gl';


### PR DESCRIPTION
## Summary
- add react-globe.gl dependency
- create new `/globe` route rendering daytime globe
- show popup for Warsaw marker with dismiss on outside click

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a39f77f7648326859e146d00463737