### PR TITLE
feat: add globe page using react-globe

### DIFF
--- a/app/globe/page.tsx
+++ b/app/globe/page.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useState } from 'react'
+
+// Dynamically import react-globe.gl to disable SSR
+const Globe = dynamic(() => import('react-globe.gl'), { ssr: false })
+
+interface PointData {
+  lat: number
+  lng: number
+  size: number
+}
+
+export default function GlobePage() {
+  const [showPopup, setShowPopup] = useState(false)
+
+  const warsaw: PointData[] = [
+    { lat: 52.2297, lng: 21.0122, size: 0.5 }
+  ]
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100vh' }}>
+      <Globe
+        globeImageUrl="//unpkg.com/three-globe/example/img/earth-blue-marble.jpg"
+        pointsData={warsaw}
+        pointAltitude={0.01}
+        pointColor={() => 'orange'}
+        pointRadius={0.5}
+        onPointClick={() => setShowPopup(true)}
+      />
+
+      {showPopup && (
+        <div
+          onClick={() => setShowPopup(false)}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: 'rgba(0,0,0,0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+        >
+          <div
+            onClick={e => e.stopPropagation()}
+            style={{ background: '#fff', padding: '1rem', borderRadius: '8px' }}
+          >
+            <h2>Warsaw</h2>
+            <p>Mockup text for Warsaw.</p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "next": "14.0.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-globe.gl": "^2.26.4",
+    "three": "^0.158.0"
   },
   "devDependencies": {
     "@types/node": "20.19.10",


### PR DESCRIPTION
## Summary
- add `/globe` route rendering a day-time globe with a clickable Warsaw marker that opens a popup overlay
- declare `react-globe.gl` and `three` dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(aborted: requires interactive setup)*
- `npm run build` *(fails: Module not found: Can't resolve 'react-globe.gl')*

------
https://chatgpt.com/codex/tasks/task_e_68a39f77f7648326859e146d00463737