### PR TITLE
Add interactive globe page with Warsaw popup

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -671,3 +671,30 @@ body {
     background: rgba(26, 26, 26, 0.9);
   }
 }
+
+/* Globe page styles */
+.globe-container {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+}
+
+.popup-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.popup-content {
+  background: var(--warm-white);
+  color: var(--charcoal);
+  padding: var(--spacing-lg);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-medium);
+  max-width: 320px;
+  text-align: center;
+}

--- a/app/globe/page.tsx
+++ b/app/globe/page.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import React, { useState } from 'react'
+import ReactDOM from 'react-dom'
+import Script from 'next/script'
+
+if (typeof window !== 'undefined') {
+  // Expose React and ReactDOM for the UMD build loaded via script tag
+  ;(window as any).React = React
+  ;(window as any).ReactDOM = ReactDOM
+}
+
+export default function GlobePage() {
+  const [GlobeComponent, setGlobeComponent] = useState<any>(null)
+  const [showPopup, setShowPopup] = useState(false)
+
+  const points = [{ lat: 52.2297, lng: 21.0122 }]
+
+  return (
+    <div className="globe-container">
+      <Script
+        src="//cdn.jsdelivr.net/npm/react-globe.gl"
+        strategy="afterInteractive"
+        onLoad={() => setGlobeComponent(() => (window as any).Globe)}
+      />
+
+      {GlobeComponent && (
+        <GlobeComponent
+          globeImageUrl="//unpkg.com/three-globe/example/img/earth-blue-marble.jpg"
+          pointsData={points}
+          pointAltitude={0.1}
+          pointColor={() => '#f1c40f'}
+          onPointClick={() => setShowPopup(true)}
+        />
+      )}
+
+      {showPopup && (
+        <div className="popup-overlay" onClick={() => setShowPopup(false)}>
+          <div className="popup-content" onClick={(e) => e.stopPropagation()}>
+            <h2>Warsaw</h2>
+            <p>This is a mockup popup for Warsaw.</p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add /globe route showing day-textured globe
- allow clicking Warsaw point to display overlay popup
- style globe page and popup

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive prompt prevented automatic run)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a39f77f7648326859e146d00463737