### PR TITLE
Add futuristic pulsing globe markers

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -608,10 +608,10 @@ body {
     padding: 4px 8px;
   }
   
-  .interaction-hint {
-    font-size: 0.8rem;
-    padding: 4px 8px;
-  }
+.interaction-hint {
+  font-size: 0.8rem;
+  padding: 4px 8px;
+}
 }
 
 /* High contrast mode support */
@@ -629,6 +629,50 @@ body {
   .handle-circle {
     border-width: 4px;
   }
+}
+
+.globe-pin {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: #fff;
+  cursor: pointer;
+  text-shadow: 0 0 4px rgba(0, 255, 255, 0.8);
+}
+
+.globe-pin .dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(0, 255, 255, 0.9);
+  box-shadow: 0 0 8px rgba(0, 255, 255, 0.8);
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(0.8);
+    box-shadow: 0 0 0 0 rgba(0, 255, 255, 0.7);
+  }
+  70% {
+    transform: scale(1.3);
+    box-shadow: 0 0 15px 10px rgba(0, 255, 255, 0);
+  }
+  100% {
+    transform: scale(0.8);
+    box-shadow: 0 0 0 0 rgba(0, 255, 255, 0);
+  }
+}
+
+.globe-pin .label {
+  margin-top: 4px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(4px);
+  font-size: 12px;
+  white-space: nowrap;
+  pointer-events: none;
 }
 
 /* Reduced motion support */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { Suspense, useEffect, useMemo, useRef, useState } from 'react'
+import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three'
 import type { GlobeMethods } from 'react-globe.gl'
 import ImageComparison from './components/ImageComparison'
@@ -63,6 +63,18 @@ export default function Home() {
       },
     ],
     []
+  )
+
+  const renderMarker = useCallback(
+    (d: LocationPoint) => {
+      const el = document.createElement('div')
+      el.className = 'globe-pin'
+      el.innerHTML = `<div class="dot"></div><div class="label">${d.name}</div>`
+      el.style.pointerEvents = 'auto'
+      el.onclick = () => setSelectedLocation(d)
+      return el
+    },
+    [setSelectedLocation]
   )
 
   useEffect(() => {
@@ -165,11 +177,8 @@ export default function Home() {
               backgroundColor="rgba(0, 0, 0, 0)"
               globeImageUrl="https://unpkg.com/three-globe/example/img/earth-blue-marble.jpg"
               bumpImageUrl="https://unpkg.com/three-globe/example/img/earth-topology.png"
-              pointsData={locations}
-              pointAltitude={() => 0.12}
-              pointColor={(p: any) => (p as LocationPoint).color || '#ff8c00'}
-              pointRadius={(p: any) => (p as LocationPoint).size || 0.3}
-              onPointClick={(p) => setSelectedLocation(p as LocationPoint)}
+              htmlElementsData={locations}
+              htmlElement={renderMarker}
             />
           </Suspense>
         )}


### PR DESCRIPTION
## Summary
- Replace basic globe points with neon pulsing dots that display their location names
- Style marker labels with frosted glass for a clean, futuristic aesthetic

## Testing
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a46d0a27908326936b9841501440ce