### PR TITLE
Add placeholder cities with navigation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,50 +20,218 @@ interface LocationPoint {
 export default function Home() {
   const globeRef = useRef<GlobeMethods | undefined>(undefined)
   const [isMounted, setIsMounted] = useState(false)
-  const [selectedLocation, setSelectedLocation] = useState<LocationPoint | null>(null)
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
   const [viewport, setViewport] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
+
+  const placeholderBefore = {
+    src: '/images/urban/pawia.webp',
+    alt: 'Placeholder before',
+    label: 'Today',
+  }
+  const placeholderAfter = {
+    src: '/images/urban/pawia-punk.webp',
+    alt: 'Placeholder after',
+    label: 'Solarpunk',
+  }
 
   const locations: LocationPoint[] = useMemo(
     () => [
       {
-        name: 'Warsaw',
-        lat: 52.2297,
-        lng: 21.0122,
+        name: 'New York, USA',
+        lat: 40.7128,
+        lng: -74.006,
         size: 0.35,
         color: '#ffa500',
-        beforeImage: { src: '/images/urban/pawia.webp', alt: 'Warsaw today', label: 'Today' },
-        afterImage: { src: '/images/urban/pawia-punk.webp', alt: 'Warsaw solarpunk', label: 'Solarpunk' },
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
       },
       {
-        name: 'Las Vegas - Strip',
-        lat: 36.1147,
-        lng: -115.1728,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: { src: '/images/urban/bellagio.png', alt: 'Las Vegas strip', label: 'Today' },
-        afterImage: { src: '/images/urban/bellagio2.png', alt: 'Las Vegas strip solarpunk', label: 'Solarpunk' },
-      },
-      {
-        name: 'Las Vegas - Downtown',
-        lat: 36.1699,
-        lng: -115.1398,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: { src: '/images/urban/vegas1.jpg', alt: 'Las Vegas downtown', label: 'Today' },
-        afterImage: { src: '/images/urban/vegas2.png', alt: 'Las Vegas downtown solarpunk', label: 'Solarpunk' },
-      },
-      {
-        name: 'Paris',
+        name: 'Paris, France',
         lat: 48.8566,
         lng: 2.3522,
         size: 0.35,
         color: '#ffa500',
-        beforeImage: { src: '/images/urban/eifel.webp', alt: 'Paris today', label: 'Today' },
-        afterImage: { src: '/images/urban/eifel2.png', alt: 'Paris solarpunk', label: 'Solarpunk' },
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'London, UK',
+        lat: 51.5074,
+        lng: -0.1278,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Barcelona, Spain',
+        lat: 41.3851,
+        lng: 2.1734,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Shanghai, China',
+        lat: 31.2304,
+        lng: 121.4737,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Tokyo, Japan',
+        lat: 35.6762,
+        lng: 139.6503,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Singapore, Singapore',
+        lat: 1.3521,
+        lng: 103.8198,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'São Paulo, Brazil',
+        lat: -23.5505,
+        lng: -46.6333,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Mexico City, Mexico',
+        lat: 19.4326,
+        lng: -99.1332,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Istanbul, Turkey',
+        lat: 41.0082,
+        lng: 28.9784,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Saint Petersburg, Russia',
+        lat: 59.9311,
+        lng: 30.3609,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Dubai, United Arab Emirates',
+        lat: 25.2048,
+        lng: 55.2708,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Rome, Italy',
+        lat: 41.9028,
+        lng: 12.4964,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Warsaw, Poland',
+        lat: 52.2297,
+        lng: 21.0122,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'New Delhi, India',
+        lat: 28.6139,
+        lng: 77.209,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Seoul, South Korea',
+        lat: 37.5665,
+        lng: 126.978,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Sydney, Australia',
+        lat: -33.8688,
+        lng: 151.2093,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Buenos Aires, Argentina',
+        lat: -34.6037,
+        lng: -58.3816,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Lisbon, Portugal',
+        lat: 38.7223,
+        lng: -9.1393,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
+      },
+      {
+        name: 'Zurich, Switzerland',
+        lat: 47.3769,
+        lng: 8.5417,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: placeholderBefore,
+        afterImage: placeholderAfter,
       },
     ],
     []
   )
+
+  const selectedLocation =
+    selectedIndex !== null ? locations[selectedIndex] : null
+
+  const handlePrev = () => {
+    if (selectedIndex === null) return
+    setSelectedIndex((selectedIndex - 1 + locations.length) % locations.length)
+  }
+
+  const handleNext = () => {
+    if (selectedIndex === null) return
+    setSelectedIndex((selectedIndex + 1) % locations.length)
+  }
 
   useEffect(() => {
     setIsMounted(true)
@@ -150,7 +318,7 @@ export default function Home() {
     }
   }, [isMounted])
 
-  const handleBackgroundClick = () => setSelectedLocation(null)
+  const handleBackgroundClick = () => setSelectedIndex(null)
   const stopPropagation: React.MouseEventHandler<HTMLDivElement> = (e) => e.stopPropagation()
 
   return (
@@ -169,19 +337,19 @@ export default function Home() {
               htmlLat={(p: any) => (p as LocationPoint).lat}
               htmlLng={(p: any) => (p as LocationPoint).lng}
               htmlAltitude={() => 0.01}
-              htmlElement={(p: any) => {
-                const el = document.createElement('div')
-                const color = (p as LocationPoint).color || '#ffa500'
-                el.className = 'globe-marker'
-                el.innerHTML = `<div class="pulse-dot" style="--dot-color:${color}"></div><div class="label">${(p as LocationPoint).name}</div>`
-                el.style.pointerEvents = 'auto'
-                el.onclick = () => setSelectedLocation(p as LocationPoint)
-                return el
-              }}
-            />
-          </Suspense>
-        )}
-      </div>
+                htmlElement={(p: any) => {
+                  const el = document.createElement('div')
+                  const color = (p as LocationPoint).color || '#ffa500'
+                  el.className = 'globe-marker'
+                  el.innerHTML = `<div class="pulse-dot" style="--dot-color:${color}"></div><div class="label">${(p as LocationPoint).name}</div>`
+                  el.style.pointerEvents = 'auto'
+                  el.onclick = () => setSelectedIndex(locations.indexOf(p as LocationPoint))
+                  return el
+                }}
+              />
+            </Suspense>
+          )}
+        </div>
 
       {selectedLocation && (
         <div
@@ -205,19 +373,19 @@ export default function Home() {
               boxShadow: '0 10px 40px rgba(0,255,242,0.2)',
               backdropFilter: 'blur(12px)',
               border: '1px solid rgba(255,255,255,0.3)',
-              width: 'min(90vw, 560px)',
-              padding: 24,
-            }}
-          >
+                width: 'min(90vw, 700px)',
+                padding: 24,
+              }}
+            >
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
-              <h2 style={{ fontSize: 20, margin: 0 }}>{selectedLocation.name}</h2>
-              <button
-                onClick={() => setSelectedLocation(null)}
-                style={{
-                  border: 'none',
-                  background: 'transparent',
-                  fontSize: 22,
-                  lineHeight: 1,
+                <h2 style={{ fontSize: 20, margin: 0 }}>{selectedLocation.name}</h2>
+                <button
+                  onClick={() => setSelectedIndex(null)}
+                  style={{
+                    border: 'none',
+                    background: 'transparent',
+                    fontSize: 22,
+                    lineHeight: 1,
                   cursor: 'pointer',
                   color: '#fff',
                 }}
@@ -226,14 +394,74 @@ export default function Home() {
                 ×
               </button>
             </div>
-            <ImageComparison
-              beforeImage={selectedLocation.beforeImage}
-              afterImage={selectedLocation.afterImage}
-            />
+              <ImageComparison
+                beforeImage={selectedLocation.beforeImage}
+                afterImage={selectedLocation.afterImage}
+              />
+              <div style={{ marginTop: 16 }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    color: '#fff',
+                  }}
+                >
+                  <button
+                    onClick={handlePrev}
+                    style={{
+                      border: 'none',
+                      background: 'transparent',
+                      color: '#fff',
+                      fontSize: 24,
+                      cursor: 'pointer',
+                    }}
+                    aria-label="Previous city"
+                  >
+                    ←
+                  </button>
+                  <div style={{ flex: 1, textAlign: 'center' }}>{selectedLocation.name}</div>
+                  <button
+                    onClick={handleNext}
+                    style={{
+                      border: 'none',
+                      background: 'transparent',
+                      color: '#fff',
+                      fontSize: 24,
+                      cursor: 'pointer',
+                    }}
+                    aria-label="Next city"
+                  >
+                    →
+                  </button>
+                </div>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    marginTop: 8,
+                  }}
+                >
+                  {locations.map((_, idx) => (
+                    <span
+                      key={idx}
+                      onClick={() => setSelectedIndex(idx)}
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: '50%',
+                        margin: '0 4px',
+                        background: idx === selectedIndex ? '#fff' : 'rgba(255,255,255,0.4)',
+                        cursor: 'pointer',
+                      }}
+                    />
+                  ))}
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
-      )}
-    </div>
-  )
-}
+        )}
+      </div>
+    )
+  }
 


### PR DESCRIPTION
## Summary
- Replace map locations with provided city list and placeholder images
- Add popup navigation with arrows, city indicators, and larger layout

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4ad0e43ac8326b3965c263b090efc