### PR TITLE
Remove top bar and refine globe layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -101,48 +101,6 @@ body {
   z-index: -1;
 }
 
-/* Header Styles */
-.site-header {
-  background: rgba(255, 255, 255, 0.9);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(135, 169, 107, 0.2);
-  position: sticky;
-  top: 0;
-  z-index: 100;
-  padding: var(--spacing-md) 0;
-}
-
-.header-content {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 var(--spacing-md);
-  text-align: center;
-}
-
-.site-title {
-  font-family: var(--font-display);
-  font-size: 2.5rem;
-  font-weight: 600;
-  color: var(--forest-green);
-  margin-bottom: var(--spacing-xs);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacing-sm);
-}
-
-.leaf-icon {
-  font-size: 2rem;
-  animation: gentle-sway 3s ease-in-out infinite;
-}
-
-.site-subtitle {
-  font-size: 1.1rem;
-  color: var(--moss-green);
-  font-weight: 400;
-  opacity: 0.8;
-}
-
 /* Main Content */
 .main-content {
   position: relative;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,18 +21,7 @@ export default function RootLayout({
       </head>
       <body className="antialiased">
         <div className="app-container">
-          <header className="site-header">
-            <div className="header-content">
-              <h1 className="site-title">
-                <span className="leaf-icon">🌿</span>
-                Solar Explorer
-              </h1>
-              <p className="site-subtitle">Interactive solarpunk voyages</p>
-            </div>
-          </header>
-          <main className="main-content">
-            {children}
-          </main>
+          <main className="main-content">{children}</main>
         </div>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -64,15 +64,6 @@ export default function Home() {
         afterImage: placeholderAfter,
       },
       {
-        name: 'Barcelona, Spain',
-        lat: 41.3851,
-        lng: 2.1734,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
         name: 'Shanghai, China',
         lat: 31.2304,
         lng: 121.4737,
@@ -145,15 +136,6 @@ export default function Home() {
         afterImage: placeholderAfter,
       },
       {
-        name: 'Rome, Italy',
-        lat: 41.9028,
-        lng: 12.4964,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
         name: 'Warsaw, Poland',
         lat: 52.2297,
         lng: 21.0122,
@@ -207,21 +189,16 @@ export default function Home() {
         beforeImage: placeholderBefore,
         afterImage: placeholderAfter,
       },
-      {
-        name: 'Zurich, Switzerland',
-        lat: 47.3769,
-        lng: 8.5417,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
     ],
     []
   )
 
   const selectedLocation =
     selectedIndex !== null ? locations[selectedIndex] : null
+
+  const isDesktop = viewport.width >= 1024
+  const globeWidth =
+    isDesktop && selectedLocation ? viewport.width * 0.55 : viewport.width
 
   const handlePrev = () => {
     if (selectedIndex === null) return
@@ -267,6 +244,26 @@ export default function Home() {
       canceled = true
     }
   }, [isMounted])
+
+  useEffect(() => {
+    if (!isMounted) return
+    const globe = globeRef.current
+    if (!globe) return
+    const controls = globe.controls()
+    if (selectedLocation) {
+      if (controls) controls.autoRotate = false
+      globe.pointOfView(
+        {
+          lat: selectedLocation.lat,
+          lng: selectedLocation.lng,
+          altitude: 1.5,
+        },
+        1000
+      )
+    } else if (controls) {
+      controls.autoRotate = true
+    }
+  }, [selectedLocation, isMounted])
 
   // Add semi-transparent clouds layer
   useEffect(() => {
@@ -321,14 +318,149 @@ export default function Home() {
   const handleBackgroundClick = () => setSelectedIndex(null)
   const stopPropagation: React.MouseEventHandler<HTMLDivElement> = (e) => e.stopPropagation()
 
+  const cardContent = selectedLocation ? (
+    <div
+      style={{
+        background: 'rgba(255,255,255,0.35)',
+        color: '#e0f7ff',
+        borderRadius: 20,
+        boxShadow: '0 12px 48px rgba(0,255,242,0.25)',
+        backdropFilter: 'blur(14px)',
+        border: '1px solid rgba(255,255,255,0.35)',
+        width: isDesktop ? 'min(95%, 700px)' : 'min(95vw, 700px)',
+        padding: 32,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 16,
+        }}
+      >
+        <h2 style={{ fontSize: 24, margin: 0 }}>{selectedLocation.name}</h2>
+        <button
+          onClick={() => setSelectedIndex(null)}
+          style={{
+            border: 'none',
+            background: 'transparent',
+            fontSize: 26,
+            lineHeight: 1,
+            cursor: 'pointer',
+            color: '#fff',
+          }}
+          aria-label="Close"
+        >
+          ×
+        </button>
+      </div>
+      <ImageComparison
+        beforeImage={selectedLocation.beforeImage}
+        afterImage={selectedLocation.afterImage}
+      />
+      <div style={{ marginTop: 20 }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            color: '#fff',
+          }}
+        >
+          <button
+            onClick={handlePrev}
+            style={{
+              border: 'none',
+              background: 'transparent',
+              color: '#fff',
+              fontSize: 28,
+              cursor: 'pointer',
+            }}
+            aria-label="Previous city"
+          >
+            ←
+          </button>
+          <div
+            style={{ flex: 1, textAlign: 'center', fontSize: 20 }}
+          >
+            {selectedLocation.name}
+          </div>
+          <button
+            onClick={handleNext}
+            style={{
+              border: 'none',
+              background: 'transparent',
+              color: '#fff',
+              fontSize: 28,
+              cursor: 'pointer',
+            }}
+            aria-label="Next city"
+          >
+            →
+          </button>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            marginTop: 12,
+          }}
+        >
+          {locations.map((_, idx) => (
+            <span
+              key={idx}
+              onClick={() => setSelectedIndex(idx)}
+              style={{
+                width: 10,
+                height: 10,
+                borderRadius: '50%',
+                margin: '0 6px',
+                background: idx === selectedIndex ? '#fff' : 'rgba(255,255,255,0.4)',
+                cursor: 'pointer',
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  ) : null
+
   return (
-    <div style={{ position: 'relative' }}>
-      <div style={{ width: '100%', height: viewport.height }}>
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: viewport.height,
+        display: isDesktop && selectedLocation ? 'flex' : 'block',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      {isDesktop && selectedLocation && (
+        <div
+          style={{
+            flex: '0 0 45%',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            padding: 32,
+          }}
+        >
+          {cardContent}
+        </div>
+      )}
+      <div
+        style={{
+          flex: isDesktop && selectedLocation ? '0 0 55%' : '1 0 100%',
+          height: viewport.height,
+        }}
+      >
         {isMounted && (
           <Suspense fallback={null}>
             <Globe
               ref={globeRef}
-              width={viewport.width}
+              width={globeWidth}
               height={viewport.height}
               backgroundColor="rgba(0, 0, 0, 0)"
               globeImageUrl="https://unpkg.com/three-globe/example/img/earth-blue-marble.jpg"
@@ -337,21 +469,20 @@ export default function Home() {
               htmlLat={(p: any) => (p as LocationPoint).lat}
               htmlLng={(p: any) => (p as LocationPoint).lng}
               htmlAltitude={() => 0.01}
-                htmlElement={(p: any) => {
-                  const el = document.createElement('div')
-                  const color = (p as LocationPoint).color || '#ffa500'
-                  el.className = 'globe-marker'
-                  el.innerHTML = `<div class="pulse-dot" style="--dot-color:${color}"></div><div class="label">${(p as LocationPoint).name}</div>`
-                  el.style.pointerEvents = 'auto'
-                  el.onclick = () => setSelectedIndex(locations.indexOf(p as LocationPoint))
-                  return el
-                }}
-              />
-            </Suspense>
-          )}
-        </div>
-
-      {selectedLocation && (
+              htmlElement={(p: any) => {
+                const el = document.createElement('div')
+                const color = (p as LocationPoint).color || '#ffa500'
+                el.className = 'globe-marker'
+                el.innerHTML = `<div class="pulse-dot" style="--dot-color:${color}"></div><div class="label">${(p as LocationPoint).name}</div>`
+                el.style.pointerEvents = 'auto'
+                el.onclick = () => setSelectedIndex(locations.indexOf(p as LocationPoint))
+                return el
+              }}
+            />
+          </Suspense>
+        )}
+      </div>
+      {!isDesktop && selectedLocation && (
         <div
           onClick={handleBackgroundClick}
           style={{
@@ -364,104 +495,10 @@ export default function Home() {
             zIndex: 50,
           }}
         >
-          <div
-            onClick={stopPropagation}
-            style={{
-              background: 'rgba(255,255,255,0.25)',
-              color: '#e0f7ff',
-              borderRadius: 16,
-              boxShadow: '0 10px 40px rgba(0,255,242,0.2)',
-              backdropFilter: 'blur(12px)',
-              border: '1px solid rgba(255,255,255,0.3)',
-                width: 'min(90vw, 700px)',
-                padding: 24,
-              }}
-            >
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
-                <h2 style={{ fontSize: 20, margin: 0 }}>{selectedLocation.name}</h2>
-                <button
-                  onClick={() => setSelectedIndex(null)}
-                  style={{
-                    border: 'none',
-                    background: 'transparent',
-                    fontSize: 22,
-                    lineHeight: 1,
-                  cursor: 'pointer',
-                  color: '#fff',
-                }}
-                aria-label="Close"
-              >
-                ×
-              </button>
-            </div>
-              <ImageComparison
-                beforeImage={selectedLocation.beforeImage}
-                afterImage={selectedLocation.afterImage}
-              />
-              <div style={{ marginTop: 16 }}>
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    color: '#fff',
-                  }}
-                >
-                  <button
-                    onClick={handlePrev}
-                    style={{
-                      border: 'none',
-                      background: 'transparent',
-                      color: '#fff',
-                      fontSize: 24,
-                      cursor: 'pointer',
-                    }}
-                    aria-label="Previous city"
-                  >
-                    ←
-                  </button>
-                  <div style={{ flex: 1, textAlign: 'center' }}>{selectedLocation.name}</div>
-                  <button
-                    onClick={handleNext}
-                    style={{
-                      border: 'none',
-                      background: 'transparent',
-                      color: '#fff',
-                      fontSize: 24,
-                      cursor: 'pointer',
-                    }}
-                    aria-label="Next city"
-                  >
-                    →
-                  </button>
-                </div>
-                <div
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    marginTop: 8,
-                  }}
-                >
-                  {locations.map((_, idx) => (
-                    <span
-                      key={idx}
-                      onClick={() => setSelectedIndex(idx)}
-                      style={{
-                        width: 8,
-                        height: 8,
-                        borderRadius: '50%',
-                        margin: '0 4px',
-                        background: idx === selectedIndex ? '#fff' : 'rgba(255,255,255,0.4)',
-                        cursor: 'pointer',
-                      }}
-                    />
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
-    )
-  }
+          <div onClick={stopPropagation}>{cardContent}</div>
+        </div>
+      )}
+    </div>
+  )
+}
 


### PR DESCRIPTION
## Summary
- Remove header bar and associated styles
- Shift globe aside on desktop and enlarge info card for clarity
- Rotate globe to highlight the city shown in the card and pause auto-spin
- Trim crowded European markers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4b38be41483268b9c1538c3483e03