### PR TITLE
Map city images to globe and pulse slider handle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -344,6 +344,7 @@ body {
 
 .after-image {
   z-index: 2;
+  transition: clip-path 12s ease-in-out;
 }
 
 .before-image {
@@ -365,8 +366,7 @@ body {
 }
 
 .before-label {
-  left: var(--spacing-md);
-  background: rgba(214, 40, 40, 0.9);
+  right: var(--spacing-md);
 }
 
 .after-label {
@@ -383,6 +383,7 @@ body {
   z-index: 10;
   transform: translateX(-2px);
   pointer-events: none;
+  transition: left 12s ease-in-out;
 }
 
 .handle-line {
@@ -407,11 +408,22 @@ body {
   box-shadow: var(--shadow-medium);
   border: 3px solid white;
   transition: all var(--transition-fast);
+  animation: slider-pulse 4s ease-in-out infinite;
 }
 
 .image-comparison-container:hover .handle-circle {
   transform: translate(-50%, -50%) scale(1.1);
   background: var(--moss-green);
+  animation: none;
+}
+
+.image-comparison-container.dragging .handle-circle {
+  animation: none;
+}
+
+.image-comparison-container.dragging .after-image,
+.image-comparison-container.dragging .slider-handle {
+  transition: none;
 }
 
 .handle-icon {
@@ -447,18 +459,24 @@ body {
 }
 
 .loading-spinner {
-  margin-bottom: var(--spacing-md);
+  display: flex;
+  gap: 8px;
 }
 
-.spinner-leaf {
-  font-size: 3rem;
-  animation: spin-grow 2s ease-in-out infinite;
+.loading-spinner .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--moss-green);
+  animation: dot-bounce 1.4s infinite both;
 }
 
-.loading-overlay p {
-  color: var(--moss-green);
-  font-size: 1.1rem;
-  font-weight: 500;
+.loading-spinner .dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.loading-spinner .dot:nth-child(3) {
+  animation-delay: 0.4s;
 }
 
 /* Interaction Hint */
@@ -476,13 +494,17 @@ body {
   align-items: center;
   gap: var(--spacing-xs);
   backdrop-filter: blur(10px);
-  opacity: 0;
+  opacity: 1;
   transition: opacity var(--transition-medium);
   z-index: 5;
 }
 
 .image-comparison-container:hover .interaction-hint {
-  opacity: 1;
+  opacity: 0;
+}
+
+.image-comparison-container.dragging .interaction-hint {
+  opacity: 0;
 }
 
 .hint-arrow {
@@ -528,12 +550,21 @@ body {
   }
 }
 
-@keyframes spin-grow {
-  0%, 100% { 
-    transform: scale(1) rotate(0deg); 
+@keyframes slider-pulse {
+  0%, 100% {
+    transform: translate(-50%, -50%) scale(1);
   }
-  50% { 
-    transform: scale(1.2) rotate(180deg); 
+  50% {
+    transform: translate(-50%, -50%) scale(1.1);
+  }
+}
+
+@keyframes dot-bounce {
+  0%, 80%, 100% {
+    transform: scale(0);
+  }
+  40% {
+    transform: scale(1);
   }
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,7 @@ export default function Home() {
   const [isMounted, setIsMounted] = useState(false)
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
   const [viewport, setViewport] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
+  const [globeVisible, setGlobeVisible] = useState(false)
 
   const placeholderBefore = {
     src: '/images/urban/pawia.webp',
@@ -30,167 +31,100 @@ export default function Home() {
   }
   const placeholderAfter = {
     src: '/images/urban/pawia-punk.webp',
-    alt: 'Placeholder after',
-    label: 'Solarpunk',
+    alt: 'Placeholder future',
+    label: 'Future',
+  }
+  const cityImages: Record<string, { before: string; after?: string }> = {
+    'New York, USA': {
+      before: '/images/urban/newyork1.jpg',
+      after: '/images/urban/newyork2.jpg',
+    },
+    'Paris, France': {
+      before: '/images/urban/paris1.webp',
+      after: '/images/urban/paris2.png',
+    },
+    'London, UK': {
+      before: '/images/urban/london1.jpeg',
+    },
+    'Shanghai, China': {
+      before: '/images/urban/shanghai-rails1.jpg',
+      after: '/images/urban/shanghai-rails2.png',
+    },
+    'Tokyo, Japan': {
+      before: '/images/urban/tokyo1.jpg',
+    },
+    'Singapore, Singapore': {
+      before: '/images/urban/singapore1.jpg',
+    },
+    'São Paulo, Brazil': {
+      before: '/images/urban/saopaulo1.jpeg',
+    },
+    'Mexico City, Mexico': {
+      before: '/images/urban/mexico1.jpeg',
+    },
+    'Istanbul, Turkey': {
+      before: '/images/urban/istanbul1.jpeg',
+    },
+    'Saint Petersburg, Russia': {
+      before: '/images/urban/saintpetersburg1.jpg',
+    },
+    'Warsaw, Poland': {
+      before: '/images/urban/warsaw1.jpeg',
+    },
+    'New Delhi, India': {
+      before: '/images/urban/newdelhi1.jpg',
+    },
+    'Seoul, South Korea': {
+      before: '/images/urban/seoul1.jpg',
+    },
+    'Sydney, Australia': {
+      before: '/images/urban/sydney1.jpeg',
+    },
+    'Buenos Aires, Argentina': {
+      before: '/images/urban/buenosaires1.jpg',
+    },
+    'Lisbon, Portugal': {
+      before: '/images/urban/lisbon1.jpg',
+    },
   }
 
+  const baseLocations = [
+    { name: 'New York, USA', lat: 40.7128, lng: -74.006 },
+    { name: 'Paris, France', lat: 48.8566, lng: 2.3522 },
+    { name: 'London, UK', lat: 51.5074, lng: -0.1278 },
+    { name: 'Shanghai, China', lat: 31.2304, lng: 121.4737 },
+    { name: 'Tokyo, Japan', lat: 35.6762, lng: 139.6503 },
+    { name: 'Singapore, Singapore', lat: 1.3521, lng: 103.8198 },
+    { name: 'São Paulo, Brazil', lat: -23.5505, lng: -46.6333 },
+    { name: 'Mexico City, Mexico', lat: 19.4326, lng: -99.1332 },
+    { name: 'Istanbul, Turkey', lat: 41.0082, lng: 28.9784 },
+    { name: 'Saint Petersburg, Russia', lat: 59.9311, lng: 30.3609 },
+    { name: 'Dubai, United Arab Emirates', lat: 25.2048, lng: 55.2708 },
+    { name: 'Warsaw, Poland', lat: 52.2297, lng: 21.0122 },
+    { name: 'New Delhi, India', lat: 28.6139, lng: 77.209 },
+    { name: 'Seoul, South Korea', lat: 37.5665, lng: 126.978 },
+    { name: 'Sydney, Australia', lat: -33.8688, lng: 151.2093 },
+    { name: 'Buenos Aires, Argentina', lat: -34.6037, lng: -58.3816 },
+    { name: 'Lisbon, Portugal', lat: 38.7223, lng: -9.1393 },
+  ]
+
   const locations: LocationPoint[] = useMemo(
-    () => [
-      {
-        name: 'New York, USA',
-        lat: 40.7128,
-        lng: -74.006,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'Paris, France',
-        lat: 48.8566,
-        lng: 2.3522,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'London, UK',
-        lat: 51.5074,
-        lng: -0.1278,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'Shanghai, China',
-        lat: 31.2304,
-        lng: 121.4737,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'Tokyo, Japan',
-        lat: 35.6762,
-        lng: 139.6503,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'Singapore, Singapore',
-        lat: 1.3521,
-        lng: 103.8198,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'São Paulo, Brazil',
-        lat: -23.5505,
-        lng: -46.6333,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'Mexico City, Mexico',
-        lat: 19.4326,
-        lng: -99.1332,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'Istanbul, Turkey',
-        lat: 41.0082,
-        lng: 28.9784,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'Saint Petersburg, Russia',
-        lat: 59.9311,
-        lng: 30.3609,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'Dubai, United Arab Emirates',
-        lat: 25.2048,
-        lng: 55.2708,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'Warsaw, Poland',
-        lat: 52.2297,
-        lng: 21.0122,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'New Delhi, India',
-        lat: 28.6139,
-        lng: 77.209,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'Seoul, South Korea',
-        lat: 37.5665,
-        lng: 126.978,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'Sydney, Australia',
-        lat: -33.8688,
-        lng: 151.2093,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'Buenos Aires, Argentina',
-        lat: -34.6037,
-        lng: -58.3816,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-      {
-        name: 'Lisbon, Portugal',
-        lat: 38.7223,
-        lng: -9.1393,
-        size: 0.35,
-        color: '#ffa500',
-        beforeImage: placeholderBefore,
-        afterImage: placeholderAfter,
-      },
-    ],
-    []
+    () =>
+      baseLocations.map((loc) => {
+        const images = cityImages[loc.name]
+        return {
+          ...loc,
+          size: 0.35,
+          color: '#ffa500',
+          beforeImage: images?.before
+            ? { src: images.before, alt: `${loc.name} today`, label: 'Today' }
+            : placeholderBefore,
+          afterImage: images?.after
+            ? { src: images.after, alt: `${loc.name} future`, label: 'Future' }
+            : placeholderAfter,
+        }
+      }),
+    [placeholderBefore, placeholderAfter]
   )
 
   const selectedLocation =
@@ -231,12 +165,13 @@ export default function Home() {
         requestAnimationFrame(tryInit)
         return
       }
-      globe.pointOfView({ lat: 30, lng: 10, altitude: 1.8 }, 1500)
+      globe.pointOfView({ lat: 30, lng: 10, altitude: 1.8 }, 4000)
       const controls = globe.controls()
       if (controls) {
         controls.autoRotate = true
-        controls.autoRotateSpeed = 0.35
+        controls.autoRotateSpeed = 0.15
       }
+      setGlobeVisible(true)
     }
     tryInit()
     return () => {
@@ -253,12 +188,12 @@ export default function Home() {
       controls.autoRotate = false
       globe.pointOfView(
         { lat: selectedLocation.lat, lng: selectedLocation.lng, altitude: 1.2 },
-        1000
+        2000
       )
     } else {
       controls.autoRotate = true
-      controls.autoRotateSpeed = 0.35
-      globe.pointOfView({ lat: 30, lng: 10, altitude: 1.8 }, 1000)
+      controls.autoRotateSpeed = 0.15
+      globe.pointOfView({ lat: 30, lng: 10, altitude: 1.8 }, 2000)
     }
   }, [selectedLocation, isMounted])
 
@@ -446,6 +381,7 @@ export default function Home() {
               ref={globeRef}
               width={globeWidth}
               height={viewport.height}
+              style={{ opacity: globeVisible ? 1 : 0, transition: 'opacity 4s ease' }}
               backgroundColor="rgba(0, 0, 0, 0)"
               globeImageUrl="https://unpkg.com/three-globe/example/img/earth-blue-marble.jpg"
               bumpImageUrl="https://unpkg.com/three-globe/example/img/earth-topology.png"


### PR DESCRIPTION
## Summary
- Map available urban before/after images to globe locations and fall back to placeholders when missing
- Start image comparisons near the "today" view, add a pulsing slider handle, and move "Today/Future" labels to the upper-right
- Reset loading state on city change to avoid image flashes while new photos load
- Slow auto-reveal comparison slider with dot-spinner preload, visible hint until hover, and smoother fading globe intro

## Testing
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c676e56c83268b0f375c0f53eaba