### PR TITLE
Refine card layout and default to dark theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -21,10 +21,10 @@
   --clay-red: #d62828;
   
   /* Neutral Tones */
-  --cream: #fefae0;
-  --warm-white: #faf8f5;
-  --soft-gray: #f4f3ee;
-  --charcoal: #264653;
+  --cream: #1e1e1e;
+  --warm-white: #1a1a1a;
+  --soft-gray: #2a2a2a;
+  --charcoal: #e0e0e0;
   --deep-forest: #1a3a1f;
   
   /* Gradients */
@@ -99,6 +99,10 @@ body {
     radial-gradient(circle at 80% 20%, rgba(168, 218, 220, 0.1) 0%, transparent 50%);
   pointer-events: none;
   z-index: -1;
+}
+
+.site-header {
+  background: rgba(26, 26, 26, 0.9);
 }
 
 /* Main Content */
@@ -248,12 +252,12 @@ body {
 
 .comparison-item {
   margin-bottom: var(--spacing-2xl);
-  background: rgba(255, 255, 255, 0.7);
+  background: rgba(42, 42, 42, 0.8);
   border-radius: var(--radius-organic);
   padding: var(--spacing-xl);
   box-shadow: var(--shadow-soft);
   backdrop-filter: blur(5px);
-  border: 1px solid rgba(167, 201, 87, 0.2);
+  border: 1px solid rgba(167, 201, 87, 0.3);
   position: relative;
   overflow: hidden;
   transition: all var(--transition-medium);
@@ -689,30 +693,30 @@ body {
   }
 }
 
-/* Dark mode support */
-@media (prefers-color-scheme: dark) {
+/* Light mode support */
+@media (prefers-color-scheme: light) {
   :root {
-    --warm-white: #1a1a1a;
-    --soft-gray: #2a2a2a;
-    --cream: #1e1e1e;
-    --charcoal: #e0e0e0;
+    --warm-white: #faf8f5;
+    --soft-gray: #f4f3ee;
+    --cream: #fefae0;
+    --charcoal: #264653;
   }
-  
+
   .app-container {
     background: linear-gradient(
       180deg,
-      #1a1a1a 0%,
-      #2a2a2a 50%,
-      #1e1e1e 100%
+      #faf8f5 0%,
+      #f4f3ee 50%,
+      #fefae0 100%
     );
   }
-  
+
   .comparison-item {
-    background: rgba(42, 42, 42, 0.8);
-    border-color: rgba(167, 201, 87, 0.3);
+    background: rgba(255, 255, 255, 0.7);
+    border-color: rgba(167, 201, 87, 0.2);
   }
-  
+
   .site-header {
-    background: rgba(26, 26, 26, 0.9);
+    background: rgba(250, 248, 245, 0.9);
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -141,6 +141,7 @@ export default function Home() {
     selectedIndex !== null ? locations[selectedIndex] : null
 
   const isDesktop = viewport.width >= 1024
+  const isLargeScreen = viewport.width >= 1600
   const globeWidth = viewport.width
 
   const handlePrev = () => {
@@ -268,14 +269,14 @@ export default function Home() {
   const cardContent = selectedLocation ? (
     <div
       style={{
-        background: 'rgba(255,255,255,0.35)',
-        color: '#264653',
+        background: 'rgba(13, 42, 67, 0.75)',
+        color: '#a8dadc',
         borderRadius: 20,
-        boxShadow: '0 10px 40px rgba(0,0,0,0.15)',
+        boxShadow: '0 10px 40px rgba(0,0,0,0.35)',
         backdropFilter: 'blur(12px)',
-        border: '1px solid rgba(255,255,255,0.4)',
-        width: isDesktop ? '600px' : 'min(90vw, 700px)',
-        maxWidth: isDesktop ? 600 : undefined,
+        border: '1px solid rgba(168,218,220,0.4)',
+        width: isDesktop ? (isLargeScreen ? '800px' : '600px') : 'min(90vw, 700px)',
+        maxWidth: isDesktop ? (isLargeScreen ? 800 : 600) : undefined,
         padding: 32,
       }}
     >
@@ -296,7 +297,7 @@ export default function Home() {
             fontSize: 26,
             lineHeight: 1,
             cursor: 'pointer',
-            color: '#264653',
+            color: '#a8dadc',
           }}
           aria-label="Close"
         >
@@ -313,7 +314,7 @@ export default function Home() {
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
-            color: '#264653',
+            color: '#a8dadc',
           }}
         >
           <button
@@ -321,7 +322,7 @@ export default function Home() {
             style={{
               border: 'none',
               background: 'transparent',
-              color: '#264653',
+              color: '#a8dadc',
               fontSize: 28,
               cursor: 'pointer',
             }}
@@ -335,7 +336,7 @@ export default function Home() {
             style={{
               border: 'none',
               background: 'transparent',
-              color: '#264653',
+              color: '#a8dadc',
               fontSize: 28,
               cursor: 'pointer',
             }}
@@ -362,8 +363,8 @@ export default function Home() {
                 margin: '0 4px',
                 background:
                   idx === selectedIndex
-                    ? '#264653'
-                    : 'rgba(38,70,83,0.3)',
+                    ? '#a8dadc'
+                    : 'rgba(168,218,220,0.3)',
                 cursor: 'pointer',
               }}
             />
@@ -387,7 +388,10 @@ export default function Home() {
           width: '100%',
           height: '100%',
           transition: 'transform 0.6s ease',
-          transform: isDesktop && selectedLocation ? 'translateX(20%)' : 'none',
+          transform:
+            isDesktop && selectedLocation
+              ? `translateX(${isLargeScreen ? 10 : 20}%)`
+              : 'none',
         }}
       >
         {isMounted && (
@@ -423,7 +427,7 @@ export default function Home() {
           style={{
             position: 'absolute',
             top: '50%',
-            left: '5%',
+            left: isLargeScreen ? '10%' : '5%',
             transform: 'translateY(-50%)',
             zIndex: 10,
           }}


### PR DESCRIPTION
## Summary
- Expand info card and adjust positioning for large screens so it overlaps the globe and stays near the center
- Introduce default dark styling and cooler blue card palette for a more professional look
- Make dark theme the base style and fallback to light scheme only when requested

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d637b9b883269a8563f75a3c230c