### PR TITLE
Center comparison card and default dark mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -21,10 +21,10 @@
   --clay-red: #d62828;
   
   /* Neutral Tones */
-  --cream: #fefae0;
-  --warm-white: #faf8f5;
-  --soft-gray: #f4f3ee;
-  --charcoal: #264653;
+  --cream: #1e1e1e;
+  --warm-white: #1a1a1a;
+  --soft-gray: #2a2a2a;
+  --charcoal: #e0e0e0;
   --deep-forest: #1a3a1f;
   
   /* Gradients */
@@ -246,14 +246,15 @@ body {
   padding: 0 var(--spacing-md);
 }
 
+
 .comparison-item {
   margin-bottom: var(--spacing-2xl);
-  background: rgba(255, 255, 255, 0.7);
+  background: rgba(42, 42, 42, 0.8);
   border-radius: var(--radius-organic);
   padding: var(--spacing-xl);
   box-shadow: var(--shadow-soft);
   backdrop-filter: blur(5px);
-  border: 1px solid rgba(167, 201, 87, 0.2);
+  border: 1px solid rgba(167, 201, 87, 0.3);
   position: relative;
   overflow: hidden;
   transition: all var(--transition-medium);
@@ -690,29 +691,3 @@ body {
 }
 
 /* Dark mode support */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --warm-white: #1a1a1a;
-    --soft-gray: #2a2a2a;
-    --cream: #1e1e1e;
-    --charcoal: #e0e0e0;
-  }
-  
-  .app-container {
-    background: linear-gradient(
-      180deg,
-      #1a1a1a 0%,
-      #2a2a2a 50%,
-      #1e1e1e 100%
-    );
-  }
-  
-  .comparison-item {
-    background: rgba(42, 42, 42, 0.8);
-    border-color: rgba(167, 201, 87, 0.3);
-  }
-  
-  .site-header {
-    background: rgba(26, 26, 26, 0.9);
-  }
-}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -268,14 +268,14 @@ export default function Home() {
   const cardContent = selectedLocation ? (
     <div
       style={{
-        background: 'rgba(255,255,255,0.35)',
-        color: '#264653',
+        background: 'rgba(13,27,42,0.85)',
+        color: '#a8dadc',
         borderRadius: 20,
-        boxShadow: '0 10px 40px rgba(0,0,0,0.15)',
+        boxShadow: '0 10px 40px rgba(0,0,0,0.5)',
         backdropFilter: 'blur(12px)',
-        border: '1px solid rgba(255,255,255,0.4)',
-        width: isDesktop ? '600px' : 'min(90vw, 700px)',
-        maxWidth: isDesktop ? 600 : undefined,
+        border: '1px solid rgba(168,218,220,0.3)',
+        width: isDesktop ? 'min(60vw, 800px)' : 'min(90vw, 700px)',
+        maxWidth: isDesktop ? 800 : undefined,
         padding: 32,
       }}
     >
@@ -296,7 +296,7 @@ export default function Home() {
             fontSize: 26,
             lineHeight: 1,
             cursor: 'pointer',
-            color: '#264653',
+            color: '#a8dadc',
           }}
           aria-label="Close"
         >
@@ -313,7 +313,7 @@ export default function Home() {
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
-            color: '#264653',
+            color: '#a8dadc',
           }}
         >
           <button
@@ -321,7 +321,7 @@ export default function Home() {
             style={{
               border: 'none',
               background: 'transparent',
-              color: '#264653',
+              color: '#a8dadc',
               fontSize: 28,
               cursor: 'pointer',
             }}
@@ -335,7 +335,7 @@ export default function Home() {
             style={{
               border: 'none',
               background: 'transparent',
-              color: '#264653',
+              color: '#a8dadc',
               fontSize: 28,
               cursor: 'pointer',
             }}
@@ -362,8 +362,8 @@ export default function Home() {
                 margin: '0 4px',
                 background:
                   idx === selectedIndex
-                    ? '#264653'
-                    : 'rgba(38,70,83,0.3)',
+                    ? '#a8dadc'
+                    : 'rgba(168,218,220,0.3)',
                 cursor: 'pointer',
               }}
             />
@@ -387,7 +387,7 @@ export default function Home() {
           width: '100%',
           height: '100%',
           transition: 'transform 0.6s ease',
-          transform: isDesktop && selectedLocation ? 'translateX(20%)' : 'none',
+          transform: 'none',
         }}
       >
         {isMounted && (
@@ -423,8 +423,8 @@ export default function Home() {
           style={{
             position: 'absolute',
             top: '50%',
-            left: '5%',
-            transform: 'translateY(-50%)',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
             zIndex: 10,
           }}
         >


### PR DESCRIPTION
## Summary
- enlarge and center comparison card on desktop globe view
- set dark theme as default and restyle card with blue accents
- adjust comparison item styling for consistent dark mode

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d637b9b883269a8563f75a3c230c