### PR TITLE
feat: default dark theme and desktop card adjustments

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -21,10 +21,10 @@
   --clay-red: #d62828;
   
   /* Neutral Tones */
-  --cream: #fefae0;
-  --warm-white: #faf8f5;
-  --soft-gray: #f4f3ee;
-  --charcoal: #264653;
+  --cream: #1e1e1e;
+  --warm-white: #1a1a1a;
+  --soft-gray: #2a2a2a;
+  --charcoal: #e0e0e0;
   --deep-forest: #1a3a1f;
   
   /* Gradients */
@@ -80,9 +80,9 @@ body {
   min-height: 100vh;
   background: linear-gradient(
     180deg,
-    var(--warm-white) 0%,
-    var(--soft-gray) 50%,
-    var(--cream) 100%
+    #1a1a1a 0%,
+    #2a2a2a 50%,
+    #1e1e1e 100%
   );
   position: relative;
 }
@@ -311,7 +311,7 @@ body {
   overflow: hidden;
   cursor: col-resize;
   box-shadow: var(--shadow-organic);
-  background: var(--stone-gray);
+  background: #102a43;
   user-select: none;
   transition: height var(--transition-medium), box-shadow var(--transition-medium), transform var(--transition-medium);
   touch-action: none; /* allow pointer events to manage pan */
@@ -686,33 +686,5 @@ body {
   .page-container {
     opacity: 1;
     transform: none;
-  }
-}
-
-/* Dark mode support */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --warm-white: #1a1a1a;
-    --soft-gray: #2a2a2a;
-    --cream: #1e1e1e;
-    --charcoal: #e0e0e0;
-  }
-  
-  .app-container {
-    background: linear-gradient(
-      180deg,
-      #1a1a1a 0%,
-      #2a2a2a 50%,
-      #1e1e1e 100%
-    );
-  }
-  
-  .comparison-item {
-    background: rgba(42, 42, 42, 0.8);
-    border-color: rgba(167, 201, 87, 0.3);
-  }
-  
-  .site-header {
-    background: rgba(26, 26, 26, 0.9);
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -141,6 +141,7 @@ export default function Home() {
     selectedIndex !== null ? locations[selectedIndex] : null
 
   const isDesktop = viewport.width >= 1024
+  const isLargeDesktop = viewport.width >= 1800
   const globeWidth = viewport.width
 
   const handlePrev = () => {
@@ -268,14 +269,14 @@ export default function Home() {
   const cardContent = selectedLocation ? (
     <div
       style={{
-        background: 'rgba(255,255,255,0.35)',
-        color: '#264653',
+        background: 'rgba(16, 42, 67, 0.85)',
+        color: '#e0f0ff',
         borderRadius: 20,
-        boxShadow: '0 10px 40px rgba(0,0,0,0.15)',
-        backdropFilter: 'blur(12px)',
-        border: '1px solid rgba(255,255,255,0.4)',
-        width: isDesktop ? '600px' : 'min(90vw, 700px)',
-        maxWidth: isDesktop ? 600 : undefined,
+        boxShadow: '0 10px 40px rgba(0,0,0,0.3)',
+        backdropFilter: 'blur(8px)',
+        border: '1px solid rgba(80,150,200,0.4)',
+        width: isDesktop ? (isLargeDesktop ? '800px' : '600px') : 'min(90vw, 700px)',
+        maxWidth: isDesktop ? (isLargeDesktop ? 800 : 600) : undefined,
         padding: 32,
       }}
     >
@@ -296,7 +297,7 @@ export default function Home() {
             fontSize: 26,
             lineHeight: 1,
             cursor: 'pointer',
-            color: '#264653',
+            color: '#e0f0ff',
           }}
           aria-label="Close"
         >
@@ -313,7 +314,7 @@ export default function Home() {
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
-            color: '#264653',
+            color: '#e0f0ff',
           }}
         >
           <button
@@ -321,7 +322,7 @@ export default function Home() {
             style={{
               border: 'none',
               background: 'transparent',
-              color: '#264653',
+              color: '#e0f0ff',
               fontSize: 28,
               cursor: 'pointer',
             }}
@@ -335,7 +336,7 @@ export default function Home() {
             style={{
               border: 'none',
               background: 'transparent',
-              color: '#264653',
+              color: '#e0f0ff',
               fontSize: 28,
               cursor: 'pointer',
             }}
@@ -362,8 +363,8 @@ export default function Home() {
                 margin: '0 4px',
                 background:
                   idx === selectedIndex
-                    ? '#264653'
-                    : 'rgba(38,70,83,0.3)',
+                    ? '#e0f0ff'
+                    : 'rgba(224,240,255,0.3)',
                 cursor: 'pointer',
               }}
             />
@@ -387,7 +388,12 @@ export default function Home() {
           width: '100%',
           height: '100%',
           transition: 'transform 0.6s ease',
-          transform: isDesktop && selectedLocation ? 'translateX(20%)' : 'none',
+          transform:
+            isDesktop && selectedLocation
+              ? isLargeDesktop
+                ? 'translateX(10%)'
+                : 'translateX(20%)'
+              : 'none',
         }}
       >
         {isMounted && (
@@ -423,7 +429,7 @@ export default function Home() {
           style={{
             position: 'absolute',
             top: '50%',
-            left: '5%',
+            left: isLargeDesktop ? '20%' : '5%',
             transform: 'translateY(-50%)',
             zIndex: 10,
           }}


### PR DESCRIPTION
## Summary
- use dark theme by default with blue-tinted card styling
- enlarge and center overlay card on ultra-wide desktops
- adjust image comparison container for dark look

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d637b9b883269a8563f75a3c230c