### PR TITLE
Refine large-screen card and enable default dark theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -21,10 +21,10 @@
   --clay-red: #d62828;
   
   /* Neutral Tones */
-  --cream: #fefae0;
-  --warm-white: #faf8f5;
-  --soft-gray: #f4f3ee;
-  --charcoal: #264653;
+  --cream: #1e1e1e;
+  --warm-white: #1a1a1a;
+  --soft-gray: #2a2a2a;
+  --charcoal: #e0e0e0;
   --deep-forest: #1a3a1f;
   
   /* Gradients */
@@ -69,8 +69,8 @@ html {
 
 body {
   font-family: var(--font-primary);
-  background: var(--warm-white);
-  color: var(--charcoal);
+  background: #1a1a1a;
+  color: #e0e0e0;
   line-height: 1.6;
   overflow-x: hidden;
 }
@@ -80,11 +80,15 @@ body {
   min-height: 100vh;
   background: linear-gradient(
     180deg,
-    var(--warm-white) 0%,
-    var(--soft-gray) 50%,
-    var(--cream) 100%
+    #1a1a1a 0%,
+    #2a2a2a 50%,
+    #1e1e1e 100%
   );
   position: relative;
+}
+
+.site-header {
+  background: rgba(26, 26, 26, 0.9);
 }
 
 .app-container::before {
@@ -248,12 +252,12 @@ body {
 
 .comparison-item {
   margin-bottom: var(--spacing-2xl);
-  background: rgba(255, 255, 255, 0.7);
+  background: rgba(42, 42, 42, 0.8);
   border-radius: var(--radius-organic);
   padding: var(--spacing-xl);
   box-shadow: var(--shadow-soft);
   backdrop-filter: blur(5px);
-  border: 1px solid rgba(167, 201, 87, 0.2);
+  border: 1px solid rgba(167, 201, 87, 0.3);
   position: relative;
   overflow: hidden;
   transition: all var(--transition-medium);
@@ -690,29 +694,3 @@ body {
 }
 
 /* Dark mode support */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --warm-white: #1a1a1a;
-    --soft-gray: #2a2a2a;
-    --cream: #1e1e1e;
-    --charcoal: #e0e0e0;
-  }
-  
-  .app-container {
-    background: linear-gradient(
-      180deg,
-      #1a1a1a 0%,
-      #2a2a2a 50%,
-      #1e1e1e 100%
-    );
-  }
-  
-  .comparison-item {
-    background: rgba(42, 42, 42, 0.8);
-    border-color: rgba(167, 201, 87, 0.3);
-  }
-  
-  .site-header {
-    background: rgba(26, 26, 26, 0.9);
-  }
-}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -141,6 +141,7 @@ export default function Home() {
     selectedIndex !== null ? locations[selectedIndex] : null
 
   const isDesktop = viewport.width >= 1024
+  const isLargeDesktop = viewport.width >= 1600
   const globeWidth = viewport.width
 
   const handlePrev = () => {
@@ -268,14 +269,14 @@ export default function Home() {
   const cardContent = selectedLocation ? (
     <div
       style={{
-        background: 'rgba(255,255,255,0.35)',
-        color: '#264653',
+        background: 'rgba(20,40,60,0.8)',
+        color: '#a8dadc',
         borderRadius: 20,
-        boxShadow: '0 10px 40px rgba(0,0,0,0.15)',
-        backdropFilter: 'blur(12px)',
-        border: '1px solid rgba(255,255,255,0.4)',
-        width: isDesktop ? '600px' : 'min(90vw, 700px)',
-        maxWidth: isDesktop ? 600 : undefined,
+        boxShadow: '0 10px 40px rgba(0,0,0,0.5)',
+        backdropFilter: 'blur(8px)',
+        border: '1px solid rgba(168,218,220,0.4)',
+        width: isDesktop ? (isLargeDesktop ? '750px' : '600px') : 'min(90vw, 700px)',
+        maxWidth: isDesktop ? (isLargeDesktop ? 750 : 600) : undefined,
         padding: 32,
       }}
     >
@@ -296,7 +297,7 @@ export default function Home() {
             fontSize: 26,
             lineHeight: 1,
             cursor: 'pointer',
-            color: '#264653',
+            color: '#a8dadc',
           }}
           aria-label="Close"
         >
@@ -308,23 +309,23 @@ export default function Home() {
         afterImage={selectedLocation.afterImage}
       />
       <div style={{ marginTop: 24 }}>
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            color: '#264653',
-          }}
-        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              color: '#a8dadc',
+            }}
+          >
           <button
             onClick={handlePrev}
             style={{
               border: 'none',
               background: 'transparent',
-              color: '#264653',
-              fontSize: 28,
-              cursor: 'pointer',
-            }}
+            color: '#a8dadc',
+            fontSize: 28,
+            cursor: 'pointer',
+          }}
             aria-label="Previous city"
           >
             ←
@@ -335,10 +336,10 @@ export default function Home() {
             style={{
               border: 'none',
               background: 'transparent',
-              color: '#264653',
-              fontSize: 28,
-              cursor: 'pointer',
-            }}
+            color: '#a8dadc',
+            fontSize: 28,
+            cursor: 'pointer',
+          }}
             aria-label="Next city"
           >
             →
@@ -362,8 +363,8 @@ export default function Home() {
                 margin: '0 4px',
                 background:
                   idx === selectedIndex
-                    ? '#264653'
-                    : 'rgba(38,70,83,0.3)',
+                    ? '#a8dadc'
+                    : 'rgba(168,218,220,0.3)',
                 cursor: 'pointer',
               }}
             />
@@ -387,7 +388,12 @@ export default function Home() {
           width: '100%',
           height: '100%',
           transition: 'transform 0.6s ease',
-          transform: isDesktop && selectedLocation ? 'translateX(20%)' : 'none',
+          transform:
+            isDesktop && selectedLocation
+              ? isLargeDesktop
+                ? 'translateX(10%)'
+                : 'translateX(20%)'
+              : 'none',
         }}
       >
         {isMounted && (
@@ -423,8 +429,10 @@ export default function Home() {
           style={{
             position: 'absolute',
             top: '50%',
-            left: '5%',
-            transform: 'translateY(-50%)',
+            left: isLargeDesktop ? '50%' : '5%',
+            transform: isLargeDesktop
+              ? 'translate(-50%, -50%)'
+              : 'translateY(-50%)',
             zIndex: 10,
           }}
         >


### PR DESCRIPTION
## Summary
- Widen and center location card on large displays, with a slick blue styling
- Shift globe slightly less and overlay card for improved layout
- Default site to dark mode and update global palette accordingly

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d637b9b883269a8563f75a3c230c