### PR TITLE
feat: auto-link city image pairs to globe markers

### DIFF
--- a/app/components/ImageComparison.tsx
+++ b/app/components/ImageComparison.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Image from 'next/image'
 import { useState, useRef, useEffect, useCallback } from 'react'
 
 interface ImageData {
@@ -162,14 +163,18 @@ export default function ImageComparison({ beforeImage, afterImage }: ImageCompar
     >
       {/* Before Image */}
       <div className="image-wrapper before-image">
-        <img
+        <Image
           ref={beforeImageRef}
           src={beforeImage.src}
           alt={beforeImage.alt}
+          width={1920}
+          height={1080}
+          quality={80}
           onLoad={markBeforeDone}
           onError={markBeforeDone}
-          loading="eager"
+          priority
           draggable={false}
+          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
         />
         <div className="image-label before-label">
           {beforeImage.label}
@@ -181,14 +186,18 @@ export default function ImageComparison({ beforeImage, afterImage }: ImageCompar
         className="image-wrapper after-image"
         style={{ clipPath: `inset(0 ${100 - sliderPosition}% 0 0)` }}
       >
-        <img
+        <Image
           ref={afterImageRef}
           src={afterImage.src}
           alt={afterImage.alt}
+          width={1920}
+          height={1080}
+          quality={80}
           onLoad={markAfterDone}
           onError={markAfterDone}
-          loading="eager"
+          priority
           draggable={false}
+          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
         />
         <div className="image-label after-label">
           {afterImage.label}

--- a/app/data/locations.ts
+++ b/app/data/locations.ts
@@ -1,0 +1,269 @@
+export interface LocationPoint {
+  lat: number;
+  lng: number;
+  size: number;
+  color: string;
+  name: string;
+  beforeImage: { src: string; alt: string; label: string };
+  afterImage: { src: string; alt: string; label: string };
+}
+
+const locations: LocationPoint[] = [
+  {
+    "name": "Buenos Aires, Argentina",
+    "lat": -34.6037,
+    "lng": -58.3816,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/buenosaires1.jpg",
+      "alt": "Buenos Aires, Argentina today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/buenosaires2.png",
+      "alt": "Buenos Aires, Argentina future",
+      "label": "Future"
+    }
+  },
+  {
+    "name": "Istanbul, Turkey",
+    "lat": 41.0082,
+    "lng": 28.9784,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/istanbul1.jpeg",
+      "alt": "Istanbul, Turkey today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/istanbul2.png",
+      "alt": "Istanbul, Turkey future",
+      "label": "Future"
+    }
+  },
+  {
+    "name": "Lisbon, Portugal",
+    "lat": 38.7223,
+    "lng": -9.1393,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/lisbon1.jpg",
+      "alt": "Lisbon, Portugal today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/lisbon2.png",
+      "alt": "Lisbon, Portugal future",
+      "label": "Future"
+    }
+  },
+  {
+    "name": "Mexico City, Mexico",
+    "lat": 19.4326,
+    "lng": -99.1332,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/mexico1.jpeg",
+      "alt": "Mexico City, Mexico today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/mexico2.png",
+      "alt": "Mexico City, Mexico future",
+      "label": "Future"
+    }
+  },
+  {
+    "name": "New Delhi, India",
+    "lat": 28.6139,
+    "lng": 77.209,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/newdelhi1.jpg",
+      "alt": "New Delhi, India today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/newdelhi2.png",
+      "alt": "New Delhi, India future",
+      "label": "Future"
+    }
+  },
+  {
+    "name": "New York, USA",
+    "lat": 40.7128,
+    "lng": -74.006,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/newyork1.jpg",
+      "alt": "New York, USA today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/newyork2.png",
+      "alt": "New York, USA future",
+      "label": "Future"
+    }
+  },
+  {
+    "name": "Paris, France",
+    "lat": 48.8566,
+    "lng": 2.3522,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/paris1.webp",
+      "alt": "Paris, France today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/paris2.png",
+      "alt": "Paris, France future",
+      "label": "Future"
+    }
+  },
+  {
+    "name": "Saint Petersburg, Russia",
+    "lat": 59.9311,
+    "lng": 30.3609,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/saintpetersburg1.jpg",
+      "alt": "Saint Petersburg, Russia today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/saintpetersburg2.png",
+      "alt": "Saint Petersburg, Russia future",
+      "label": "Future"
+    }
+  },
+  {
+    "name": "Seoul, South Korea",
+    "lat": 37.5665,
+    "lng": 126.978,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/seoul1.jpg",
+      "alt": "Seoul, South Korea today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/seoul2.png",
+      "alt": "Seoul, South Korea future",
+      "label": "Future"
+    }
+  },
+  {
+    "name": "Shanghai, China",
+    "lat": 31.2304,
+    "lng": 121.4737,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/shanghai-rails1.jpg",
+      "alt": "Shanghai, China today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/shanghai-rails2.png",
+      "alt": "Shanghai, China future",
+      "label": "Future"
+    }
+  },
+  {
+    "name": "Singapore, Singapore",
+    "lat": 1.3521,
+    "lng": 103.8198,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/singapore1.jpg",
+      "alt": "Singapore, Singapore today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/singapore2.png",
+      "alt": "Singapore, Singapore future",
+      "label": "Future"
+    }
+  },
+  {
+    "name": "Sydney, Australia",
+    "lat": -33.8688,
+    "lng": 151.2093,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/sydney1.jpeg",
+      "alt": "Sydney, Australia today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/sydney2.png",
+      "alt": "Sydney, Australia future",
+      "label": "Future"
+    }
+  },
+  {
+    "name": "Bellagio Fountain, USA",
+    "lat": 36.1126,
+    "lng": -115.1767,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/vegas-bellagio1.png",
+      "alt": "Bellagio Fountain, USA today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/vegas-bellagio2.png",
+      "alt": "Bellagio Fountain, USA future",
+      "label": "Future"
+    }
+  },
+  {
+    "name": "Las Vegas, USA",
+    "lat": 36.1699,
+    "lng": -115.1398,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/vegas1.jpg",
+      "alt": "Las Vegas, USA today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/vegas2.png",
+      "alt": "Las Vegas, USA future",
+      "label": "Future"
+    }
+  },
+  {
+    "name": "Warsaw, Poland",
+    "lat": 52.2297,
+    "lng": 21.0122,
+    "size": 0.35,
+    "color": "#ffa500",
+    "beforeImage": {
+      "src": "/images/urban/warsaw1.jpeg",
+      "alt": "Warsaw, Poland today",
+      "label": "Today"
+    },
+    "afterImage": {
+      "src": "/images/urban/warsaw2.png",
+      "alt": "Warsaw, Poland future",
+      "label": "Future"
+    }
+  }
+];
+
+export default locations;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,21 +1,12 @@
 'use client'
 
-import React, { Suspense, useEffect, useMemo, useRef, useState } from 'react'
+import React, { Suspense, useEffect, useRef, useState } from 'react'
 import * as THREE from 'three'
 import type { GlobeMethods } from 'react-globe.gl'
 import ImageComparison from './components/ImageComparison'
+import locations, { LocationPoint } from './data/locations'
 
 const Globe = React.lazy(() => import('react-globe.gl'))
-
-interface LocationPoint {
-  lat: number
-  lng: number
-  size?: number
-  color?: string
-  name: string
-  beforeImage: { src: string; alt: string; label: string }
-  afterImage: { src: string; alt: string; label: string }
-}
 
 export default function Home() {
   const globeRef = useRef<GlobeMethods | undefined>(undefined)
@@ -23,119 +14,6 @@ export default function Home() {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
   const [viewport, setViewport] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
   const [globeVisible, setGlobeVisible] = useState(false)
-
-  const placeholderBefore = {
-    src: '/images/urban/pawia.webp',
-    alt: 'Placeholder before',
-    label: 'Today',
-  }
-  const placeholderAfter = {
-    src: '/images/urban/pawia-punk.webp',
-    alt: 'Placeholder future',
-    label: 'Future',
-  }
-  const cityImages: Record<string, { before: string; after?: string }> = {
-    'Bellagio, Italy': {
-      before: '/images/urban/bellagio.png',
-      after: '/images/urban/bellagio2.png',
-    },
-    'New York, USA': {
-      before: '/images/urban/newyork1.jpg',
-      after: '/images/urban/newyork2.jpg',
-    },
-    'Paris, France': {
-      before: '/images/urban/paris1.webp',
-      after: '/images/urban/paris2.png',
-    },
-    'London, UK': {
-      before: '/images/urban/london1.jpeg',
-    },
-    'Las Vegas, USA': {
-      before: '/images/urban/vegas1.jpg',
-      after: '/images/urban/vegas2.png',
-    },
-    'Shanghai, China': {
-      before: '/images/urban/shanghai-rails1.jpg',
-      after: '/images/urban/shanghai-rails2.png',
-    },
-    'Tokyo, Japan': {
-      before: '/images/urban/tokyo1.jpg',
-    },
-    'Singapore, Singapore': {
-      before: '/images/urban/singapore1.jpg',
-    },
-    'São Paulo, Brazil': {
-      before: '/images/urban/saopaulo1.jpeg',
-    },
-    'Mexico City, Mexico': {
-      before: '/images/urban/mexico1.jpeg',
-    },
-    'Istanbul, Turkey': {
-      before: '/images/urban/istanbul1.jpeg',
-    },
-    'Saint Petersburg, Russia': {
-      before: '/images/urban/saintpetersburg1.jpg',
-    },
-    'Warsaw, Poland': {
-      before: '/images/urban/warsaw1.jpeg',
-    },
-    'New Delhi, India': {
-      before: '/images/urban/newdelhi1.jpg',
-    },
-    'Seoul, South Korea': {
-      before: '/images/urban/seoul1.jpg',
-    },
-    'Sydney, Australia': {
-      before: '/images/urban/sydney1.jpeg',
-    },
-    'Buenos Aires, Argentina': {
-      before: '/images/urban/buenosaires1.jpg',
-    },
-    'Lisbon, Portugal': {
-      before: '/images/urban/lisbon1.jpg',
-    },
-  }
-
-  const baseLocations = [
-    { name: 'Bellagio, Italy', lat: 45.9877, lng: 9.2616 },
-    { name: 'New York, USA', lat: 40.7128, lng: -74.006 },
-    { name: 'Paris, France', lat: 48.8566, lng: 2.3522 },
-    { name: 'London, UK', lat: 51.5074, lng: -0.1278 },
-    { name: 'Las Vegas, USA', lat: 36.1699, lng: -115.1398 },
-    { name: 'Shanghai, China', lat: 31.2304, lng: 121.4737 },
-    { name: 'Tokyo, Japan', lat: 35.6762, lng: 139.6503 },
-    { name: 'Singapore, Singapore', lat: 1.3521, lng: 103.8198 },
-    { name: 'São Paulo, Brazil', lat: -23.5505, lng: -46.6333 },
-    { name: 'Mexico City, Mexico', lat: 19.4326, lng: -99.1332 },
-    { name: 'Istanbul, Turkey', lat: 41.0082, lng: 28.9784 },
-    { name: 'Saint Petersburg, Russia', lat: 59.9311, lng: 30.3609 },
-    { name: 'Dubai, United Arab Emirates', lat: 25.2048, lng: 55.2708 },
-    { name: 'Warsaw, Poland', lat: 52.2297, lng: 21.0122 },
-    { name: 'New Delhi, India', lat: 28.6139, lng: 77.209 },
-    { name: 'Seoul, South Korea', lat: 37.5665, lng: 126.978 },
-    { name: 'Sydney, Australia', lat: -33.8688, lng: 151.2093 },
-    { name: 'Buenos Aires, Argentina', lat: -34.6037, lng: -58.3816 },
-    { name: 'Lisbon, Portugal', lat: 38.7223, lng: -9.1393 },
-  ]
-
-  const locations: LocationPoint[] = useMemo(
-    () =>
-      baseLocations.map((loc) => {
-        const images = cityImages[loc.name]
-        return {
-          ...loc,
-          size: 0.35,
-          color: '#ffa500',
-          beforeImage: images?.before
-            ? { src: images.before, alt: `${loc.name} today`, label: 'Today' }
-            : placeholderBefore,
-          afterImage: images?.after
-            ? { src: images.after, alt: `${loc.name} future`, label: 'Future' }
-            : placeholderAfter,
-        }
-      }),
-    [placeholderBefore, placeholderAfter]
-  )
 
   const selectedLocation =
     selectedIndex !== null ? locations[selectedIndex] : null

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "generate-locations": "node scripts/generate-locations.js"
   },
   "dependencies": {
     "next": "14.0.0",

--- a/scripts/generate-locations.js
+++ b/scripts/generate-locations.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+
+const coordinates = {
+  buenosaires: { name: 'Buenos Aires, Argentina', lat: -34.6037, lng: -58.3816 },
+  istanbul: { name: 'Istanbul, Turkey', lat: 41.0082, lng: 28.9784 },
+  lisbon: { name: 'Lisbon, Portugal', lat: 38.7223, lng: -9.1393 },
+  london: { name: 'London, UK', lat: 51.5074, lng: -0.1278 },
+  mexico: { name: 'Mexico City, Mexico', lat: 19.4326, lng: -99.1332 },
+  newdelhi: { name: 'New Delhi, India', lat: 28.6139, lng: 77.2090 },
+  newyork: { name: 'New York, USA', lat: 40.7128, lng: -74.0060 },
+  paris: { name: 'Paris, France', lat: 48.8566, lng: 2.3522 },
+  saintpetersburg: { name: 'Saint Petersburg, Russia', lat: 59.9311, lng: 30.3609 },
+  seoul: { name: 'Seoul, South Korea', lat: 37.5665, lng: 126.9780 },
+  'shanghai-rails': { name: 'Shanghai, China', lat: 31.2304, lng: 121.4737 },
+  singapore: { name: 'Singapore, Singapore', lat: 1.3521, lng: 103.8198 },
+  sydney: { name: 'Sydney, Australia', lat: -33.8688, lng: 151.2093 },
+  vegas: { name: 'Las Vegas, USA', lat: 36.1699, lng: -115.1398 },
+  'vegas-bellagio': { name: 'Bellagio Fountain, USA', lat: 36.1126, lng: -115.1767 },
+  warsaw: { name: 'Warsaw, Poland', lat: 52.2297, lng: 21.0122 },
+};
+
+const imagesDir = path.join(__dirname, '..', 'public', 'images', 'urban');
+const files = fs.readdirSync(imagesDir);
+
+const cityFiles = {};
+for (const file of files) {
+  const match = file.match(/^(.*?)(1|2)\.(jpg|jpeg|png|webp)$/i);
+  if (!match) continue;
+  const base = match[1];
+  const which = match[2];
+  if (!cityFiles[base]) cityFiles[base] = {};
+  cityFiles[base][which === '1' ? 'before' : 'after'] = `/images/urban/${file}`;
+}
+
+const locations = [];
+for (const [base, imgs] of Object.entries(cityFiles)) {
+  const coord = coordinates[base];
+  if (!coord || !imgs.before || !imgs.after) continue;
+  locations.push({
+    name: coord.name,
+    lat: coord.lat,
+    lng: coord.lng,
+    size: 0.35,
+    color: '#ffa500',
+    beforeImage: { src: imgs.before, alt: `${coord.name} today`, label: 'Today' },
+    afterImage: { src: imgs.after, alt: `${coord.name} future`, label: 'Future' },
+  });
+}
+
+const outDir = path.join(__dirname, '..', 'app', 'data');
+if (!fs.existsSync(outDir)) {
+  fs.mkdirSync(outDir, { recursive: true });
+}
+
+const content = `export interface LocationPoint {\n` +
+  `  lat: number;\n` +
+  `  lng: number;\n` +
+  `  size: number;\n` +
+  `  color: string;\n` +
+  `  name: string;\n` +
+  `  beforeImage: { src: string; alt: string; label: string };\n` +
+  `  afterImage: { src: string; alt: string; label: string };\n` +
+  `}\n\n` +
+  `const locations: LocationPoint[] = ${JSON.stringify(locations, null, 2)};\n\n` +
+  `export default locations;\n`;
+
+fs.writeFileSync(path.join(outDir, 'locations.ts'), content);
+console.log(`Generated ${locations.length} locations.`);


### PR DESCRIPTION
## Summary
- generate city location data from images and remove markers without before/after pairs
- use Next.js Image in comparison component for on-the-fly optimization
- add script to rebuild locations from public images

## Testing
- `npm run generate-locations`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dcb79b6c8326b2a62fcd8c02d562