### PR TITLE
Link urban images to globe markers and add optimization

### DIFF
--- a/app/components/ImageComparison.tsx
+++ b/app/components/ImageComparison.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useRef, useEffect, useCallback } from 'react'
+import NextImage from 'next/image'
 
 interface ImageData {
   src: string
@@ -162,14 +163,18 @@ export default function ImageComparison({ beforeImage, afterImage }: ImageCompar
     >
       {/* Before Image */}
       <div className="image-wrapper before-image">
-        <img
+        <NextImage
           ref={beforeImageRef}
           src={beforeImage.src}
           alt={beforeImage.alt}
+          fill
+          sizes="(max-width: 1280px) 100vw, 1280px"
+          quality={80}
           onLoad={markBeforeDone}
           onError={markBeforeDone}
-          loading="eager"
+          priority
           draggable={false}
+          style={{ objectFit: 'cover' }}
         />
         <div className="image-label before-label">
           {beforeImage.label}
@@ -181,14 +186,18 @@ export default function ImageComparison({ beforeImage, afterImage }: ImageCompar
         className="image-wrapper after-image"
         style={{ clipPath: `inset(0 ${100 - sliderPosition}% 0 0)` }}
       >
-        <img
+        <NextImage
           ref={afterImageRef}
           src={afterImage.src}
           alt={afterImage.alt}
+          fill
+          sizes="(max-width: 1280px) 100vw, 1280px"
+          quality={80}
           onLoad={markAfterDone}
           onError={markAfterDone}
-          loading="eager"
+          priority
           draggable={false}
+          style={{ objectFit: 'cover' }}
         />
         <div className="image-label after-label">
           {afterImage.label}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,117 +24,248 @@ export default function Home() {
   const [viewport, setViewport] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
   const [globeVisible, setGlobeVisible] = useState(false)
 
-  const placeholderBefore = {
-    src: '/images/urban/pawia.webp',
-    alt: 'Placeholder before',
-    label: 'Today',
-  }
-  const placeholderAfter = {
-    src: '/images/urban/pawia-punk.webp',
-    alt: 'Placeholder future',
-    label: 'Future',
-  }
-  const cityImages: Record<string, { before: string; after?: string }> = {
-    'Bellagio, Italy': {
-      before: '/images/urban/bellagio.png',
-      after: '/images/urban/bellagio2.png',
-    },
-    'New York, USA': {
-      before: '/images/urban/newyork1.jpg',
-      after: '/images/urban/newyork2.jpg',
-    },
-    'Paris, France': {
-      before: '/images/urban/paris1.webp',
-      after: '/images/urban/paris2.png',
-    },
-    'London, UK': {
-      before: '/images/urban/london1.jpeg',
-    },
-    'Las Vegas, USA': {
-      before: '/images/urban/vegas1.jpg',
-      after: '/images/urban/vegas2.png',
-    },
-    'Shanghai, China': {
-      before: '/images/urban/shanghai-rails1.jpg',
-      after: '/images/urban/shanghai-rails2.png',
-    },
-    'Tokyo, Japan': {
-      before: '/images/urban/tokyo1.jpg',
-    },
-    'Singapore, Singapore': {
-      before: '/images/urban/singapore1.jpg',
-    },
-    'São Paulo, Brazil': {
-      before: '/images/urban/saopaulo1.jpeg',
-    },
-    'Mexico City, Mexico': {
-      before: '/images/urban/mexico1.jpeg',
-    },
-    'Istanbul, Turkey': {
-      before: '/images/urban/istanbul1.jpeg',
-    },
-    'Saint Petersburg, Russia': {
-      before: '/images/urban/saintpetersburg1.jpg',
-    },
-    'Warsaw, Poland': {
-      before: '/images/urban/warsaw1.jpeg',
-    },
-    'New Delhi, India': {
-      before: '/images/urban/newdelhi1.jpg',
-    },
-    'Seoul, South Korea': {
-      before: '/images/urban/seoul1.jpg',
-    },
-    'Sydney, Australia': {
-      before: '/images/urban/sydney1.jpeg',
-    },
-    'Buenos Aires, Argentina': {
-      before: '/images/urban/buenosaires1.jpg',
-    },
-    'Lisbon, Portugal': {
-      before: '/images/urban/lisbon1.jpg',
-    },
-  }
-
-  const baseLocations = [
-    { name: 'Bellagio, Italy', lat: 45.9877, lng: 9.2616 },
-    { name: 'New York, USA', lat: 40.7128, lng: -74.006 },
-    { name: 'Paris, France', lat: 48.8566, lng: 2.3522 },
-    { name: 'London, UK', lat: 51.5074, lng: -0.1278 },
-    { name: 'Las Vegas, USA', lat: 36.1699, lng: -115.1398 },
-    { name: 'Shanghai, China', lat: 31.2304, lng: 121.4737 },
-    { name: 'Tokyo, Japan', lat: 35.6762, lng: 139.6503 },
-    { name: 'Singapore, Singapore', lat: 1.3521, lng: 103.8198 },
-    { name: 'São Paulo, Brazil', lat: -23.5505, lng: -46.6333 },
-    { name: 'Mexico City, Mexico', lat: 19.4326, lng: -99.1332 },
-    { name: 'Istanbul, Turkey', lat: 41.0082, lng: 28.9784 },
-    { name: 'Saint Petersburg, Russia', lat: 59.9311, lng: 30.3609 },
-    { name: 'Dubai, United Arab Emirates', lat: 25.2048, lng: 55.2708 },
-    { name: 'Warsaw, Poland', lat: 52.2297, lng: 21.0122 },
-    { name: 'New Delhi, India', lat: 28.6139, lng: 77.209 },
-    { name: 'Seoul, South Korea', lat: 37.5665, lng: 126.978 },
-    { name: 'Sydney, Australia', lat: -33.8688, lng: 151.2093 },
-    { name: 'Buenos Aires, Argentina', lat: -34.6037, lng: -58.3816 },
-    { name: 'Lisbon, Portugal', lat: 38.7223, lng: -9.1393 },
-  ]
-
   const locations: LocationPoint[] = useMemo(
-    () =>
-      baseLocations.map((loc) => {
-        const images = cityImages[loc.name]
-        return {
-          ...loc,
-          size: 0.35,
-          color: '#ffa500',
-          beforeImage: images?.before
-            ? { src: images.before, alt: `${loc.name} today`, label: 'Today' }
-            : placeholderBefore,
-          afterImage: images?.after
-            ? { src: images.after, alt: `${loc.name} future`, label: 'Future' }
-            : placeholderAfter,
-        }
-      }),
-    [placeholderBefore, placeholderAfter]
+    () => [
+      {
+        name: 'New York, USA',
+        lat: 40.7128,
+        lng: -74.006,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: {
+          src: '/images/urban/newyork1.jpg',
+          alt: 'New York, USA today',
+          label: 'Today',
+        },
+        afterImage: {
+          src: '/images/urban/newyork2.png',
+          alt: 'New York, USA future',
+          label: 'Future',
+        },
+      },
+      {
+        name: 'Paris, France',
+        lat: 48.8566,
+        lng: 2.3522,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: {
+          src: '/images/urban/paris1.webp',
+          alt: 'Paris, France today',
+          label: 'Today',
+        },
+        afterImage: {
+          src: '/images/urban/paris2.png',
+          alt: 'Paris, France future',
+          label: 'Future',
+        },
+      },
+      {
+        name: 'Las Vegas, USA',
+        lat: 36.1699,
+        lng: -115.1398,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: {
+          src: '/images/urban/vegas1.jpg',
+          alt: 'Las Vegas, USA today',
+          label: 'Today',
+        },
+        afterImage: {
+          src: '/images/urban/vegas2.png',
+          alt: 'Las Vegas, USA future',
+          label: 'Future',
+        },
+      },
+      {
+        name: 'Shanghai, China',
+        lat: 31.2304,
+        lng: 121.4737,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: {
+          src: '/images/urban/shanghai-rails1.jpg',
+          alt: 'Shanghai, China today',
+          label: 'Today',
+        },
+        afterImage: {
+          src: '/images/urban/shanghai-rails2.png',
+          alt: 'Shanghai, China future',
+          label: 'Future',
+        },
+      },
+      {
+        name: 'Singapore, Singapore',
+        lat: 1.3521,
+        lng: 103.8198,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: {
+          src: '/images/urban/singapore1.jpg',
+          alt: 'Singapore today',
+          label: 'Today',
+        },
+        afterImage: {
+          src: '/images/urban/singapore2.png',
+          alt: 'Singapore future',
+          label: 'Future',
+        },
+      },
+      {
+        name: 'Mexico City, Mexico',
+        lat: 19.4326,
+        lng: -99.1332,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: {
+          src: '/images/urban/mexico1.jpeg',
+          alt: 'Mexico City, Mexico today',
+          label: 'Today',
+        },
+        afterImage: {
+          src: '/images/urban/mexico2.png',
+          alt: 'Mexico City, Mexico future',
+          label: 'Future',
+        },
+      },
+      {
+        name: 'Istanbul, Turkey',
+        lat: 41.0082,
+        lng: 28.9784,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: {
+          src: '/images/urban/istanbul1.jpeg',
+          alt: 'Istanbul, Turkey today',
+          label: 'Today',
+        },
+        afterImage: {
+          src: '/images/urban/istanbul2.png',
+          alt: 'Istanbul, Turkey future',
+          label: 'Future',
+        },
+      },
+      {
+        name: 'Saint Petersburg, Russia',
+        lat: 59.9311,
+        lng: 30.3609,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: {
+          src: '/images/urban/saintpetersburg1.jpg',
+          alt: 'Saint Petersburg, Russia today',
+          label: 'Today',
+        },
+        afterImage: {
+          src: '/images/urban/saintpetersburg2.png',
+          alt: 'Saint Petersburg, Russia future',
+          label: 'Future',
+        },
+      },
+      {
+        name: 'Warsaw, Poland',
+        lat: 52.2297,
+        lng: 21.0122,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: {
+          src: '/images/urban/warsaw1.jpeg',
+          alt: 'Warsaw, Poland today',
+          label: 'Today',
+        },
+        afterImage: {
+          src: '/images/urban/warsaw2.png',
+          alt: 'Warsaw, Poland future',
+          label: 'Future',
+        },
+      },
+      {
+        name: 'New Delhi, India',
+        lat: 28.6139,
+        lng: 77.209,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: {
+          src: '/images/urban/newdelhi1.jpg',
+          alt: 'New Delhi, India today',
+          label: 'Today',
+        },
+        afterImage: {
+          src: '/images/urban/newdelhi2.png',
+          alt: 'New Delhi, India future',
+          label: 'Future',
+        },
+      },
+      {
+        name: 'Seoul, South Korea',
+        lat: 37.5665,
+        lng: 126.978,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: {
+          src: '/images/urban/seoul1.jpg',
+          alt: 'Seoul, South Korea today',
+          label: 'Today',
+        },
+        afterImage: {
+          src: '/images/urban/seoul2.png',
+          alt: 'Seoul, South Korea future',
+          label: 'Future',
+        },
+      },
+      {
+        name: 'Sydney, Australia',
+        lat: -33.8688,
+        lng: 151.2093,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: {
+          src: '/images/urban/sydney1.jpeg',
+          alt: 'Sydney, Australia today',
+          label: 'Today',
+        },
+        afterImage: {
+          src: '/images/urban/sydney2.png',
+          alt: 'Sydney, Australia future',
+          label: 'Future',
+        },
+      },
+      {
+        name: 'Buenos Aires, Argentina',
+        lat: -34.6037,
+        lng: -58.3816,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: {
+          src: '/images/urban/buenosaires1.jpg',
+          alt: 'Buenos Aires, Argentina today',
+          label: 'Today',
+        },
+        afterImage: {
+          src: '/images/urban/buenosaires2.png',
+          alt: 'Buenos Aires, Argentina future',
+          label: 'Future',
+        },
+      },
+      {
+        name: 'Lisbon, Portugal',
+        lat: 38.7223,
+        lng: -9.1393,
+        size: 0.35,
+        color: '#ffa500',
+        beforeImage: {
+          src: '/images/urban/lisbon1.jpg',
+          alt: 'Lisbon, Portugal today',
+          label: 'Today',
+        },
+        afterImage: {
+          src: '/images/urban/lisbon2.png',
+          alt: 'Lisbon, Portugal future',
+          label: 'Future',
+        },
+      },
+    ],
+    []
   )
 
   const selectedLocation =

--- a/package.json
+++ b/package.json
@@ -6,14 +6,16 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "optimize-images": "node scripts/optimize-images.js"
   },
   "dependencies": {
     "next": "14.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-globe.gl": "2.35.0",
-    "three": "0.179.1"
+    "three": "0.179.1",
+    "sharp": "^0.33.2"
   },
   "devDependencies": {
     "@types/node": "20.19.10",

--- a/scripts/optimize-images.js
+++ b/scripts/optimize-images.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const sharp = require('sharp');
+
+const inputDir = path.join(__dirname, '..', 'public', 'images', 'urban');
+const outputDir = path.join(inputDir, 'optimized');
+
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, { recursive: true });
+}
+
+const files = fs.readdirSync(inputDir);
+const allowed = new Set(['.jpg', '.jpeg', '.png', '.webp']);
+
+async function optimize() {
+  for (const file of files) {
+    const ext = path.extname(file).toLowerCase();
+    if (!allowed.has(ext)) continue;
+    const inputPath = path.join(inputDir, file);
+    const base = path.basename(file, ext);
+    const outputPath = path.join(outputDir, `${base}.webp`);
+    try {
+      await sharp(inputPath)
+        .resize({ width: 1280, height: 720, fit: 'inside' })
+        .toFormat('webp', { quality: 80 })
+        .toFile(outputPath);
+      console.log('Optimized', file, '->', outputPath);
+    } catch (err) {
+      console.error('Error processing', file, err);
+    }
+  }
+}
+
+optimize();


### PR DESCRIPTION
## Summary
- connect globe markers to before/after city images in public/images/urban
- drop markers missing a matching photo pair
- use Next.js `Image` with HD sizing and add a script to optimize images

## Testing
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4dcb79b6c8326b2a62fcd8c02d562